### PR TITLE
Create messages array copy before setting the state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -59,7 +59,7 @@ class App extends Component {
     });
     const room = this.drone.subscribe("observable-room");
     room.on('data', (data, member) => {
-      const messages = this.state.messages;
+      const messages = [...this.state.messages];
       messages.push({member, text: data});
       this.setState({messages});
     });


### PR DESCRIPTION
Messages were pushed directly onto state (mutating the state) whereas array should firstly be re-created, then the element can be added.